### PR TITLE
improve aerospace

### DIFF
--- a/aerospace.toml
+++ b/aerospace.toml
@@ -57,23 +57,33 @@ alt-shift-k = 'move up'
 alt-shift-l = 'move right'
 alt-shift-space = 'layout floating tiling'  # 'floating toggle' in i3
 alt-w = 'layout h_accordion'  # 'layout tabbed' in i3
-alt-q = 'close'
+alt-q = 'close'  # same as i3: mod+q kill
 
-# Move focus between monitors
-alt-comma = 'focus-monitor left'
-alt-period = 'focus-monitor right'
+# Arrow key navigation (like i3)
+alt-left = 'focus left'
+alt-down = 'focus down'
+alt-up = 'focus up'
+alt-right = 'focus right'
+alt-shift-left = 'move left'
+alt-shift-down = 'move down'
+alt-shift-up = 'move up'
+alt-shift-right = 'move right'
 
-# Move windows between monitors
-alt-shift-comma = 'move-node-to-monitor left'
-alt-shift-period = 'move-node-to-monitor right'
+# Workspace back and forth toggle (like i3: mod+Tab)
+alt-tab = 'workspace-back-and-forth'
 
-# Move workspace to different monitor
-alt-shift-m = 'move-workspace-to-monitor --wrap-around next'
+# Move workspace to left output (like i3: mod+m)
+alt-m = 'move-workspace-to-monitor --wrap-around prev'
 
 [mode.resize.binding]
 enter = 'mode main'
 esc = 'mode main'
+# Match i3 resize behavior
 h = 'resize width -50'
 j = 'resize height +50'
 k = 'resize height -50'
 l = 'resize width +50'
+left = 'resize width -50'
+down = 'resize height +50'
+up = 'resize height -50'
+right = 'resize width +50'

--- a/aerospace.toml
+++ b/aerospace.toml
@@ -9,6 +9,19 @@ enable-normalization-opposite-orientation-for-nested-containers = false
 # Mouse follows focus when focused monitor changes
 on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 
+# Workspace to monitor assignment (Yabai-style: 3 workspaces per monitor)
+[workspace-to-monitor-force-assignment]
+1 = 1    # Monitor 1: workspaces 1, 2, 3
+2 = 1
+3 = 1
+4 = 2    # Monitor 2: workspaces 4, 5, 6
+5 = 2
+6 = 2
+7 = 3    # Monitor 3: workspaces 7, 8, 9, 10
+8 = 3
+9 = 3
+10 = 3
+
 [mode.main.binding]
 alt-0 = 'workspace 10'
 alt-1 = 'workspace 1'
@@ -74,6 +87,14 @@ alt-tab = 'workspace-back-and-forth'
 
 # Move workspace to left output (like i3: mod+m)
 alt-m = 'move-workspace-to-monitor --wrap-around prev'
+
+# Focus monitors (no shift)
+alt-comma = 'focus-monitor --wrap-around prev'
+alt-period = 'focus-monitor --wrap-around next'
+
+# Move window to another monitor (with shift)
+alt-shift-comma = 'move-node-to-monitor --wrap-around prev'
+alt-shift-period = 'move-node-to-monitor --wrap-around next'
 
 [mode.resize.binding]
 enter = 'mode main'

--- a/aerospace.toml
+++ b/aerospace.toml
@@ -10,17 +10,18 @@ enable-normalization-opposite-orientation-for-nested-containers = false
 on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 
 # Workspace to monitor assignment (Yabai-style: 3 workspaces per monitor)
+# Using monitor names to ensure consistent assignment regardless of connection order
 [workspace-to-monitor-force-assignment]
-1 = 1    # Monitor 1: workspaces 1, 2, 3
-2 = 1
-3 = 1
-4 = 2    # Monitor 2: workspaces 4, 5, 6
-5 = 2
-6 = 2
-7 = 3    # Monitor 3: workspaces 7, 8, 9, 10
-8 = 3
-9 = 3
-10 = 3
+1 = 'Built-in Retina Display'    # Retina: workspaces 1, 2, 3
+2 = 'Built-in Retina Display'
+3 = 'Built-in Retina Display'
+4 = 'PB328'                      # ASUS: workspaces 4, 5, 6
+5 = 'PB328'
+6 = 'PB328'
+7 = 'HP 27f'                     # HP: workspaces 7, 8, 9, 10
+8 = 'HP 27f'
+9 = 'HP 27f'
+10 = 'HP 27f'
 
 [mode.main.binding]
 alt-0 = 'workspace 10'

--- a/aerospace.toml
+++ b/aerospace.toml
@@ -12,12 +12,12 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 # Workspace to monitor assignment (Yabai-style: 3 workspaces per monitor)
 # Using monitor names to ensure consistent assignment regardless of connection order
 [workspace-to-monitor-force-assignment]
-1 = 'Built-in Retina Display'    # Retina: workspaces 1, 2, 3
-2 = 'Built-in Retina Display'
-3 = 'Built-in Retina Display'
-4 = 'PB328'                      # ASUS: workspaces 4, 5, 6
-5 = 'PB328'
-6 = 'PB328'
+1 = 'PB328'                      # ASUS: workspaces 4, 5, 6
+2 = 'PB328'
+3 = 'PB328'
+4 = 'Built-in Retina Display'    # Retina: workspaces 1, 2, 3
+5 = 'Built-in Retina Display'
+6 = 'Built-in Retina Display'
 7 = 'HP 27f'                     # HP: workspaces 7, 8, 9, 10
 8 = 'HP 27f'
 9 = 'HP 27f'

--- a/aerospace.toml
+++ b/aerospace.toml
@@ -57,6 +57,18 @@ alt-shift-k = 'move up'
 alt-shift-l = 'move right'
 alt-shift-space = 'layout floating tiling'  # 'floating toggle' in i3
 alt-w = 'layout h_accordion'  # 'layout tabbed' in i3
+alt-q = 'close'
+
+# Move focus between monitors
+alt-comma = 'focus-monitor left'
+alt-period = 'focus-monitor right'
+
+# Move windows between monitors
+alt-shift-comma = 'move-node-to-monitor left'
+alt-shift-period = 'move-node-to-monitor right'
+
+# Move workspace to different monitor
+alt-shift-m = 'move-workspace-to-monitor --wrap-around next'
 
 [mode.resize.binding]
 enter = 'mode main'

--- a/fish/conf.d/abbr.fish
+++ b/fish/conf.d/abbr.fish
@@ -33,6 +33,7 @@ abbr -a grm 'git branch --merged | grep -v \* | xargs -I{} git branch -D {}'
 abbr -a ga git add
 abbr -a gb git branch
 abbr -a gc git commit -v
+abbr -a gclone git clone --no-single-branch --tags
 abbr -a gcfe "git config --global user.email '4514346+joamatab@users.noreply.github.com'"
 abbr -a gca git commit -va
 abbr -a gcb git checkout -b


### PR DESCRIPTION
- **improve aerospace**
- **improve aerospace**

## Summary by Sourcery

Align Aerospace window manager keybindings and resize behavior more closely with i3 conventions.

New Features:
- Add keybinding to close the focused window using Alt+Q.
- Introduce arrow key bindings for focusing and moving windows to mirror i3 navigation.
- Add a workspace back-and-forth toggle bound to Alt+Tab.
- Add a keybinding to move the current workspace to the previous monitor with wrap-around behavior.

Enhancements:
- Extend resize mode to support arrow keys in addition to hjkl for resizing windows, matching i3-style behavior.