### PR TITLE
use svim

### DIFF
--- a/aerospace.toml
+++ b/aerospace.toml
@@ -36,12 +36,7 @@ alt-8 = 'workspace 8'
 alt-9 = 'workspace 9'
 alt-e = 'layout tiles horizontal vertical'  # 'layout toggle split' in i3
 # See: https://nikitabobko.github.io/AeroSpace/goodies#open-a-new-window-with-applescript
-alt-enter = '''exec-and-forget osascript -e '
-    tell application "Terminal"
-        do script
-        activate
-    end tell'
-    '''
+alt-enter = 'exec-and-forget open -na Ghostty'
 # Consider using 'join-with' command as a 'split' replacement if you want to enable
 # normalizations
 # alt-| = 'split horizontal'

--- a/aerospace.toml
+++ b/aerospace.toml
@@ -15,13 +15,13 @@ on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
 1 = 'PB328'                      # ASUS: workspaces 4, 5, 6
 2 = 'PB328'
 3 = 'PB328'
-4 = 'Built-in Retina Display'    # Retina: workspaces 1, 2, 3
-5 = 'Built-in Retina Display'
+4 = 'PB328'
+5 = 'PB328'
 6 = 'Built-in Retina Display'
-7 = 'HP 27f'                     # HP: workspaces 7, 8, 9, 10
-8 = 'HP 27f'
-9 = 'HP 27f'
-10 = 'HP 27f'
+7 = 'Built-in Retina Display'
+8 = 'Built-in Retina Display'
+9 = 'HP 27f'                     # HP: workspaces 7, 8, 9, 10
+0 = 'HP 27f'
 
 [mode.main.binding]
 alt-0 = 'workspace 10'

--- a/borders/bordersrc
+++ b/borders/bordersrc
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+options=(
+	style=round
+	width=6.0
+	hidpi=off
+	active_color=0xc0e2e2e3
+	inactive_color=0xc02c2e34
+	background_color=0x302c2e34
+)
+
+borders "${options[@]}"

--- a/fish/conf.d/path.fish
+++ b/fish/conf.d/path.fish
@@ -1,1 +1,2 @@
 fish_add_path -m ~/.local/bin ~/.cargo/bin ~/.juliaup/bin
+test -d /Library/TeX/texbin; and fish_add_path -m /Library/TeX/texbin

--- a/gh-dash.yml
+++ b/gh-dash.yml
@@ -79,7 +79,7 @@ defaults:
 keybindings:
     prs:
         - key: m
-          command: GH_PROMPT_DISABLED=1 gh pr merge --merge --delete-branch {{.PrNumber}} -R {{.RepoName}}
+          command: gh pr merge --merge --delete-branch --yes {{.PrNumber}} -R {{.RepoName}} &
 repoPaths: {}
 theme:
     ui:

--- a/gh-dash.yml
+++ b/gh-dash.yml
@@ -79,7 +79,7 @@ defaults:
 keybindings:
     prs:
         - key: m
-          command: gh pr merge --merge --delete-branch --yes {{.PrNumber}} -R {{.RepoName}} &
+          command: gh pr merge --merge --yes {{.PrNumber}} -R {{.RepoName}} &
 repoPaths: {}
 theme:
     ui:

--- a/gitconfig
+++ b/gitconfig
@@ -67,6 +67,9 @@
 	directory = sky130
 	directory = sky130/src
 	directory = /__w/skywater130/skywater130
+	directory = sky130
+	directory = sky130/src
+	directory = /__w/skywater130/skywater130
 [interactive]
 	diffFilter = delta --color-only
 [delta]

--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -43,6 +43,8 @@
     # ~/.config/polybar:
     ~/.config/ranger:
     ~/.config/s/config: s/config
+    ~/.config/borders:
+    ~/.config/svim:
     ~/.config/starship.toml:
     ~/.config/nvim:
     ~/.config/coc/python: coc/python

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -136,7 +136,7 @@ lua << EOF
         filetypes = { "markdown", "vimwiki" },
       },
       html = {
-        enabled = true,
+        enabled = false,
         only_render_image_at_cursor = true,
         filetypes = { "html", "xhtml", "htm" },
       },

--- a/svim/blacklist
+++ b/svim/blacklist
@@ -1,4 +1,5 @@
 Ghostty
+ghostty
 Terminal
 iTerm2
 kitty
@@ -7,4 +8,5 @@ WezTerm
 tmux
 Hyper
 vim
+nvim
 fish

--- a/svim/blacklist
+++ b/svim/blacklist
@@ -6,3 +6,5 @@ Alacritty
 WezTerm
 tmux
 Hyper
+vim
+fish

--- a/svim/blacklist
+++ b/svim/blacklist
@@ -10,3 +10,8 @@ Hyper
 vim
 nvim
 fish
+Antigravity
+Cursor
+Code
+Zed
+Neovide

--- a/svim/blacklist
+++ b/svim/blacklist
@@ -1,0 +1,8 @@
+Ghostty
+Terminal
+iTerm2
+kitty
+Alacritty
+WezTerm
+tmux
+Hyper

--- a/svim/svim.sh
+++ b/svim/svim.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script is executed when either the mode changes,
+# or the commandline changes
+
+# Uncomment below if using sketchybar:
+# sketchybar --trigger svim_update MODE="$MODE" CMDLINE="$CMDLINE"

--- a/tmux.conf
+++ b/tmux.conf
@@ -59,6 +59,11 @@ set -g status-right-length '150'
 # set vi-mode
 set-window-option -g mode-keys vi
 
+# vi copy-mode bindings
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
+bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+
 # keybindings
 bind _ split-window -v -c "#{pane_current_path}"
 bind - split-window -h -c "#{pane_current_path}"

--- a/tmux.conf
+++ b/tmux.conf
@@ -67,6 +67,7 @@ bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 # keybindings
 bind _ split-window -v -c "#{pane_current_path}"
 bind - split-window -h -c "#{pane_current_path}"
+bind c new-window -c "#{pane_current_path}"
 bind Tab last-window        # move to last active window
 bind BTab switch-client -l  # move to last session
 

--- a/tmux.conf.local
+++ b/tmux.conf.local
@@ -330,7 +330,7 @@ tmux_conf_theme_clock_style="24"
 #   - disabled
 # on macOS, this requires installing reattach-to-user-namespace, see README.md
 # on Linux, this requires xsel, xclip or wl-copy
-tmux_conf_copy_to_os_clipboard=false
+tmux_conf_copy_to_os_clipboard=true
 
 
 # -- user customizations -------------------------------------------------------


### PR DESCRIPTION
- **add borders and svim**
- **ignore fish and vim**
- **fix**

## Summary by Sourcery

Add new configuration directories for borders and svim integration into the dotfiles setup.

New Features:
- Introduce configuration directory mapping for borders under ~/.config/borders.
- Introduce configuration directory mapping for svim under ~/.config/svim.

Enhancements:
- Add placeholder svim script hook for reacting to mode or command-line changes.