### PR TITLE
Fix Atuin and Neovim startup

### DIFF
--- a/fish/conf.d/atuin.env.fish
+++ b/fish/conf.d/atuin.env.fish
@@ -1,0 +1,2 @@
+
+source "$HOME/.atuin/bin/env.fish"

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -198,7 +198,7 @@ test -f "$HOME/.nvm"; and set -x NVM_DIR "$HOME/.nvm"; path_append "$HOME/.nvm/v
 # if command -v mcfly >/dev/null
 #     mcfly init fish | source
 # end
-if command -v mcfly >/dev/null
+if command -v atuin >/dev/null
     atuin init fish | source
 end
 

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -102,9 +102,6 @@ lua << EOF
 
   require("codecompanion").setup()
 
-  -- OpenClaw remote integration (node6)
-  dofile(vim.fn.expand("~/dotfiles/nvim/openclaw.lua"))
-
   -- img-clip.nvim: paste images from clipboard
   require("img-clip").setup({
     default = {


### PR DESCRIPTION
## Summary

- initialize Atuin only when the Atuin command is available
- load the Atuin environment from Fish conf.d
- remove the obsolete OpenClaw integration that referenced an untracked Lua file and broke Neovim startup

## Verification

- `nvim --headless +qa!`
- `fish --no-execute fish/config.fish fish/conf.d/atuin.env.fish`
- `git diff --check`

## Summary by Sourcery

Fix shell and Neovim startup by cleaning up Atuin initialization and removing a stale Lua integration.

New Features:
- Load Atuin environment from a dedicated Fish conf.d script when the Atuin command is available.

Bug Fixes:
- Guard Atuin initialization in Fish against missing commands to avoid startup errors.
- Remove obsolete OpenClaw Lua integration that caused Neovim to fail on startup.